### PR TITLE
Fix two bugs found in the CHashMap

### DIFF
--- a/chashmap/src/lib.rs
+++ b/chashmap/src/lib.rs
@@ -845,6 +845,7 @@ impl<K: PartialEq + Hash, V> CHashMap<K, V> {
                     // Set the bucket to a KV pair with the new value.
                     *bucket = Bucket::Contains(key, new_val);
                     // No extension required, as the bucket already had a KV pair previously.
+                    return;
                 } else {
                     // The old entry was removed, so we decrement the length of the map.
                     self.len.fetch_sub(1, ORDERING);

--- a/chashmap/src/lib.rs
+++ b/chashmap/src/lib.rs
@@ -318,7 +318,7 @@ impl<K: PartialEq + Hash, V> Table<K, V> {
 
         // Start at the first priority bucket, and then move upwards, searching for the matching
         // bucket.
-        for i in 0.. {
+        for i in 0..self.buckets.len() {
             // Get the lock of the `i`'th bucket after the first priority bucket (wrap on end).
             let lock = self.buckets[(hash + i) % self.buckets.len()].write();
 
@@ -335,8 +335,7 @@ impl<K: PartialEq + Hash, V> Table<K, V> {
             }
         }
 
-        // TODO
-        unreachable!();
+        free.expect("No free buckets found")
     }
 
     /// Lookup some key.

--- a/chashmap/src/tests.rs
+++ b/chashmap/src/tests.rs
@@ -693,3 +693,12 @@ fn capacity_not_less_than_len() {
     a.insert(item, 0);
     assert!(a.capacity() > a.len());
 }
+
+#[test]
+fn insert_into_map_full_of_free_buckets() {
+    let m = CHashMap::with_capacity(1);
+    for i in 0..100 {
+        m.insert(i, 0);
+        m.remove(&i);
+    }
+}

--- a/chashmap/src/tests.rs
+++ b/chashmap/src/tests.rs
@@ -254,7 +254,7 @@ fn alter_string() {
         x.push('a');
         Some(x)
     });
-    assert_eq!(m.len(), 2);
+    assert_eq!(m.len(), 1);
     assert_eq!(&*m.get(&1).unwrap(), "a");
 }
 


### PR DESCRIPTION
These are fixes for two issues I ran into using CHashMap:

1. If you use alter() to change the value for a key that already exists in the map, the len field gets incremented, even though it should stay the same.

2. If you do a bunch of alternating insertions and removals, you can end up with a situation where every single bucket is either used or "free" (i.e. none of them are "empty"). If you try to insert another entry when this is a case, it goes into an infinite loop when it looks for a bucket to place the new entry in, because it expects to find an "empty" bucket at the end of the cluster, but there are no empty buckets.