### PR TITLE
Fix typos in documentation

### DIFF
--- a/concurrent/src/global.rs
+++ b/concurrent/src/global.rs
@@ -36,7 +36,7 @@ pub fn export_garbage(garbage: Vec<Garbage>) {
     tick();
 }
 
-/// Atempt to garbage collect.
+/// Attempt to garbage collect.
 ///
 /// If another garbage collection is currently running, nothing will happen.
 pub fn gc() {
@@ -47,7 +47,7 @@ pub fn gc() {
 ///
 /// This shall be called when new garbage is added, as it will trigger a GC by some probability.
 pub fn tick() {
-    /// The probabiity of triggering a GC.
+    /// The probability of triggering a GC.
     ///
     /// This probability is given such that `0` corresponds to 0 and `!0` corresponds to `1`.
     const GC_PROBABILITY: usize = (!0) / 64;

--- a/concurrent/src/guard.rs
+++ b/concurrent/src/guard.rs
@@ -7,7 +7,7 @@ use {hazard, local};
 /// A RAII guard protecting from garbage collection.
 ///
 /// This "guards" the held pointer against garbage collection. First when all guards of said
-/// pointer is gone (the data is unreachable), it can be colleceted.
+/// pointer is gone (the data is unreachable), it can be collected.
 // TODO: Remove this `'static` bound.
 #[must_use]
 #[derive(Debug)]
@@ -32,7 +32,7 @@ impl<T> Guard<T> {
 
         // This fence is necessary for ensuring that `hazard` does not get reordered to after `ptr`
         // has run.
-        // TODO: Is this fence even neccessary?
+        // TODO: Is this fence even necessary?
         atomic::fence(atomic::Ordering::SeqCst);
 
         // Right here, any garbage collection is blocked, due to the hazard above. This ensures
@@ -89,7 +89,7 @@ impl<T> Guard<T> {
     /// Map the pointer to another.
     ///
     /// This allows one to map a pointer to a pointer e.g. to an object referenced by the old. It
-    /// is very convinient for creating APIs without the need for creating a wrapper type.
+    /// is very convenient for creating APIs without the need for creating a wrapper type.
     // TODO: Is this sound?
     pub fn map<U, F>(self, f: F) -> Guard<U>
     where F: FnOnce(&T) -> &U {

--- a/concurrent/src/hazard.rs
+++ b/concurrent/src/hazard.rs
@@ -7,7 +7,7 @@
 //! pair" refers to the collection of the two connected ends of the hazard (they both share a
 //! pointer to the hazard on the heap). When such pair is created, its reading end is usually
 //! stored in the global state, such that a thread can check that no hazard is matching a
-//! particular object during garbage collection. The writer part controls what the stateof the
+//! particular object during garbage collection. The writer part controls what the state of the
 //! hazard is and is usually passed around locally.
 //!
 //! The asymmetry of a hazard pair is strictly speaking not necessary, but it allows to enforce
@@ -40,7 +40,7 @@ pub enum State {
 /// This type holds an atomic pointer with the state of the hazard. It represents the same as
 /// `State` but is encoded such that it is atomically accessible.
 ///
-/// Futhermore, there is an additional state: Blocked. If the hazard is in this state, reading it
+/// Furthermore, there is an additional state: Blocked. If the hazard is in this state, reading it
 /// will block until it no longer is. This is useful for blocking garbage collection while a value
 /// is being read (avoiding the ABA problem).
 #[derive(Debug)]
@@ -52,7 +52,7 @@ pub struct Hazard {
     /// - 0: blocked.
     /// - 1: free.
     /// - 2: dead
-    /// - otherwise: protecting the address represented by the `usiz represented by the `usize`e`.
+    /// - otherwise: protecting the address represented by the `usize`.
     ptr: AtomicUsize,
 }
 
@@ -120,7 +120,7 @@ pub fn create() -> (Writer, Reader) {
 /// This wraps a hazard and provides only ability to read and deallocate it. It is created through
 /// the `create()` function.
 ///
-/// The destructor will, for the sake of safety, panick. To deallocate, use `self.destroy()`
+/// The destructor will, for the sake of safety, panic. To deallocate, use `self.destroy()`
 /// instead.
 pub struct Reader {
     /// The pointer to the heap-allocated hazard.

--- a/concurrent/src/lib.rs
+++ b/concurrent/src/lib.rs
@@ -1,7 +1,7 @@
 //! # `concurrent` — An efficient concurrent reclamation system
 //!
 //! `concurrent` builds upon hazard pointers to create a extremely performant system for
-//! concurrently handling memory. It is more general and convinient — and often also faster — than
+//! concurrently handling memory. It is more general and convenient — and often also faster — than
 //! epoch-based reclamation.
 //!
 //! ## Why?
@@ -35,7 +35,7 @@
 //! reclamation might be very very long, causing very high memory usage, and potentially OOM
 //! crashes.
 //!
-//! These issues are not hypothethical. It happened to me while testing the caching system of TFS.
+//! These issues are not hypothetical. It happened to me while testing the caching system of TFS.
 //! Essentially, the to-be-destroyed garbage accumulated several gigabytes, without ever being open
 //! to a collection cycle.
 //!
@@ -110,7 +110,7 @@ use garbage::Garbage;
 /// Note that it is not necessary to call this manually, it will do so automatically after some
 /// time has passed.
 ///
-/// However, it can be nice if you have just trashed a very memory-hungy item in the current
+/// However, it can be nice if you have just trashed a very memory-hungry item in the current
 /// thread, and want to attempt to GC it.
 ///
 /// # Other threads

--- a/concurrent/src/local.rs
+++ b/concurrent/src/local.rs
@@ -64,7 +64,7 @@ struct State {
     /// This number keeps track what hazards in `self.available_hazard` are set to state "free".
     /// Before this index, every hazard must be set to "free".
     ///
-    /// It is useful for nowing when to free the hazards to allow garbage collection.
+    /// It is useful for knowing when to free the hazards to allow garbage collection.
     available_hazards_free_before: usize,
 }
 
@@ -81,7 +81,7 @@ impl State {
             // There is; we don't need to create a new hazard.
 
             // Since the hazard popped from the cache is not blocked, we must block the hazard to
-            // satisfy the requrements of this function.
+            // satisfy the requirements of this function.
             hazard.block();
             hazard
         } else {
@@ -137,7 +137,7 @@ impl State {
 
 impl Drop for State {
     fn drop(&mut self) {
-        // The thread is exitting, thus we must export the garbage to the global state to avoid
+        // The thread is exiting, thus we must export the garbage to the global state to avoid
         // memory leaks.
         self.export_garbage();
 

--- a/concurrent/src/option.rs
+++ b/concurrent/src/option.rs
@@ -11,11 +11,11 @@ use guard::Guard;
 ///
 /// This acts as a kind of concurrent `Option<T>`.  It can be compared to `std::cell::RefCell` in
 /// some ways: It allows accessing, referencing, updating, etc., however contrary to `RefCell`,
-/// this is concurrent and has no aliasing restrictions. It is futher distinguished from
+/// this is concurrent and has no aliasing restrictions. It is further distinguished from
 /// `std::sync::AtomicPtr` in that it allows references to the inner data without the ABA problem
 /// or any variant thereof.
 ///
-/// It conviniently wraps this crates API in a seemless manner.
+/// It conveniently wraps this crates API in a seemless manner.
 #[derive(Default)]
 pub struct AtomicOption<T> {
     /// The inner atomic pointer.
@@ -104,7 +104,7 @@ impl<T> AtomicOption<T> {
     /// documentation for more information.
     pub fn compare_and_store(&self, old: Option<*const T>, mut new: Option<Box<T>>, ordering: atomic::Ordering)
     -> Result<(), Option<Box<T>>> {
-        // Convert the paramteres to raw pointers.
+        // Convert the parameters to raw pointers.
         // TODO: Use coercions.
         let new_ptr = new.as_mut().map_or(ptr::null_mut(), |x| &mut **x);
         let old_ptr = old.map_or(ptr::null_mut(), |x| x as *mut T);
@@ -147,7 +147,7 @@ impl<T> AtomicOption<T> {
     /// `compare_and_set`.
     pub fn compare_and_swap(&self, old: Option<*const T>, mut new: Option<Box<T>>, ordering: atomic::Ordering)
     -> Result<Option<Guard<T>>, (Option<Guard<T>>, Option<Box<T>>)> {
-        // Convert the paramteres to raw pointers.
+        // Convert the parameters to raw pointers.
         // TODO: Use coercions.
         let new_ptr = new.as_mut().map_or(ptr::null_mut(), |x| &mut **x);
         let old_ptr = old.map_or(ptr::null_mut(), |x| x as *mut T);


### PR DESCRIPTION
I was reading the `concurrent` implementation and fixed some typos while at it.

Thanks!