### PR TITLE
chashmap fmt improvement

### DIFF
--- a/chashmap/src/lib.rs
+++ b/chashmap/src/lib.rs
@@ -437,7 +437,7 @@ impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for Table<K, V> {
             // Check if the bucket actually contains anything.
             if let Bucket::Contains(ref key, ref val) = *lock {
                 // Write it to the output stream in a nice format.
-                write!(f, "{:?} => {:?}", key, val)?;
+                write!(f, "{:?} => {:?}; ", key, val)?;
             }
         }
 


### PR DESCRIPTION
The reason why it would be good to have this extra semicolon and space at the end of the fmt string is that when using a `CHashMap<u32,u32>` or similar, then the output looks like:

`0 => 11 => 12 => 1`

With this semicolon and space, it will be much clearer where the value ends and the key begins:

`0 => 1; 1 => 1; 2 => 1;`
