### PR TITLE
chashmap: Add support for lookup by borrowed value

### DIFF
--- a/chashmap/src/tests.rs
+++ b/chashmap/src/tests.rs
@@ -702,3 +702,10 @@ fn insert_into_map_full_of_free_buckets() {
         m.remove(&i);
     }
 }
+
+#[test]
+fn lookup_borrowed() {
+    let m = CHashMap::with_capacity(1);
+    m.insert("v".to_owned(), "value");
+    m.get("v").unwrap();
+}


### PR DESCRIPTION
Mirrors HashMap support for lookup by borrowed value. This means that CHashMap<String,String> can now be accessed via &str. 

Fixes #33