### PR TITLE
SeaHash: fix pop() and add larger output

### DIFF
--- a/seahash/src/buffer.rs
+++ b/seahash/src/buffer.rs
@@ -65,7 +65,7 @@ impl State {
 
             // Calculate the number of excessive bytes. These are bytes that could not be handled
             // in the loop above.
-            let mut excessive = buf.len() as usize + buf.as_ptr() as usize - end_ptr as usize;
+            let mut excessive = buf.len() % 32;
             // Handle the excessive bytes.
             match excessive {
                 0 => {},
@@ -73,7 +73,7 @@ impl State {
                     // 1 or more excessive.
 
                     // Write the last excessive bytes (<8 bytes).
-                    a ^= helper::read_int(slice::from_raw_parts(ptr as *const u8, excessive));
+                    a ^= helper::read_int(slice::from_raw_parts(ptr, excessive));
 
                     // Diffuse.
                     a = helper::diffuse(a);

--- a/seahash/src/buffer.rs
+++ b/seahash/src/buffer.rs
@@ -198,20 +198,15 @@ impl State {
     pub fn pop(&mut self, last: u64) {
         // Decrese the written bytes counter.
         self.written -= 8;
+        
+        // Undo rotation
+        let a = self.d;
+        self.d = self.c;
+        self.c = self.b;
+        self.b = self.a;
 
         // Remove the recently written data.
-        self.d = helper::undiffuse(self.d) ^ last;
-
-        let mut a = self.a;
-
-        //  Rotate back.
-        //  _______________________
-        // v                       |
-        // a ----> b ----> c ----> d
-        self.a = self.d;
-        self.b = a;
-        self.c = self.b;
-        self.d = self.c;
+        self.a = helper::undiffuse(a) ^ last;
     }
 
     /// Finalize the state.

--- a/seahash/src/helper.rs
+++ b/seahash/src/helper.rs
@@ -60,7 +60,7 @@ pub unsafe fn read_u64(ptr: *const u8) -> u64 {
     {
         // We cannot be sure about the memory layout of a potentially emulated 64-bit integer, so
         // we read it manually. If possible, the compiler should emit proper instructions.
-        (*(ptr as *const u32)).to_le() as u64 | ((*(ptr as *const u32)).to_le() as u64) << 32
+        (*(ptr as *const u32)).to_le() as u64 | ((*(ptr as *const u32).offset(1)).to_le() as u64) << 32
     }
 
     #[cfg(target_pointer_width = "64")]


### PR DESCRIPTION
@ticki, if you are able to review?

The larger output functions are wanted for a slightly obscure use, seeding PRNGs:
https://github.com/dhardy/rand/issues/18#issuecomment-345190063