### PR TITLE
lz4: expose Error type

### DIFF
--- a/lz4/src/lib.rs
+++ b/lz4/src/lib.rs
@@ -15,3 +15,4 @@ mod tests;
 
 pub use decompress::decompress;
 pub use compress::compress;
+pub use decompress::Error;


### PR DESCRIPTION
@ticki 

Hey, exposing error type to handle Lz4 errors 