### PR TITLE
re-export lz4::decompress::Error

### DIFF
--- a/lz4/src/lib.rs
+++ b/lz4/src/lib.rs
@@ -13,5 +13,5 @@ mod compress;
 #[cfg(test)]
 mod tests;
 
-pub use decompress::decompress;
+pub use decompress::{decompress, Error};
 pub use compress::compress;


### PR DESCRIPTION
Otherwise, you can't actually use it, because the module it's in is private.